### PR TITLE
Refactor candidates controller and add update action

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
 module Api
-  class ApiController < ActionController::API; end
+  class ApiController < ActionController::API
+    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+    private
+
+    def not_found
+      head :not_found
+    end
+  end
 end

--- a/app/controllers/api/v1/candidates_controller.rb
+++ b/app/controllers/api/v1/candidates_controller.rb
@@ -19,8 +19,6 @@ module Api
       def show
         candidate = Candidate.find(params[:id])
         render json: candidate
-      rescue ActiveRecord::RecordNotFound
-        head :not_found
       end
 
       def create
@@ -28,6 +26,13 @@ module Api
         return head :unprocessable_entity unless candidate
 
         head :created
+      end
+
+      def update
+        candidate = Candidates::UpdateUseCase.new(params[:id], candidate_params).call
+        return head :unprocessable_entity unless candidate
+
+        head :ok
       end
 
       private

--- a/app/use_cases/candidates/create_use_case.rb
+++ b/app/use_cases/candidates/create_use_case.rb
@@ -27,7 +27,7 @@ module Candidates
     end
 
     def valid?
-      Candidates::CreateValidator.valid?(candidate)
+      Candidates::UpsertValidator.valid?(candidate)
     end
   end
 end

--- a/app/use_cases/candidates/update_use_case.rb
+++ b/app/use_cases/candidates/update_use_case.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Candidates
+  class UpdateUseCase
+    def initialize(candidate_id, params)
+      @candidate_id = candidate_id
+      @params = params
+    end
+
+    def call
+      return unless valid?
+
+      candidate.update!(candidate_params)
+    end
+
+    private
+
+    def candidate
+      @candidate ||= Candidate.find(@candidate_id).tap { |c| c.assign_attributes(candidate_params) }
+    end
+
+    def candidate_params
+      {
+        name:      @params[:name],
+        email:     @params[:email],
+        birthdate: @params[:birthdate]
+      }
+    end
+
+    def valid?
+      Candidates::UpsertValidator.valid?(candidate)
+    end
+  end
+end

--- a/app/validators/candidates/upsert_validator.rb
+++ b/app/validators/candidates/upsert_validator.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 module Candidates
-  class CreateValidator < BaseValidator
+  class UpsertValidator < BaseValidator
     validates :name, presence: true
     validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
     validates :birthdate, presence: true
     validate :past_birtdate
+    validate :unique_email
 
     def past_birtdate
       return if birthdate.blank?
 
       errors.add(:birthdate, :future_date) if birthdate >= Date.current
+    end
+
+    def unique_email
+      return if email.blank?
+
+      errors.add(:email, :taken) if Candidate.exists?(email: email)
     end
   end
 end

--- a/app/validators/candidates/upsert_validator.rb
+++ b/app/validators/candidates/upsert_validator.rb
@@ -16,6 +16,7 @@ module Candidates
 
     def unique_email
       return if email.blank?
+      return unless email_changed?
 
       errors.add(:email, :taken) if Candidate.exists?(email: email)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :candidates, only: %i[create index show]
+      resources :candidates, only: %i[create index show update]
     end
   end
 

--- a/spec/requests/api/v1/candidates_request_spec.rb
+++ b/spec/requests/api/v1/candidates_request_spec.rb
@@ -82,6 +82,59 @@ RSpec.describe 'Api::V1::Candidates' do
     end
   end
 
+  describe 'PUT /:id' do
+    subject(:update_candidate) { put "/api/v1/candidates/#{candidate_id}", params: params }
+
+    let(:candidate_id) { candidate.id }
+    let(:params) { { candidate: { name: 'John Doe', email: 'john@doe.com', birthdate: 20.years.ago } } }
+    let(:candidate) { create(:candidate) }
+
+    context 'with valid params' do
+      it 'returns http ok' do
+        update_candidate
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the candidate' do
+        update_candidate
+        expect(candidate.reload).to have_attributes(
+          id:        candidate.id,
+          name:      'John Doe',
+          email:     'john@doe.com',
+          birthdate: 20.years.ago.to_date
+        )
+      end
+    end
+
+    context 'with invalid params' do
+      let(:params) { { candidate: { email: 'invalid-email' } } }
+
+      it 'returns http unprocessable entity' do
+        update_candidate
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not update the candidate' do
+        update_candidate
+        expect(candidate.reload).to have_attributes(
+          id:        candidate.id,
+          name:      candidate.name,
+          email:     candidate.email,
+          birthdate: candidate.birthdate
+        )
+      end
+    end
+
+    context 'with non-existing candidate' do
+      let(:candidate_id) { 'invalid-id' }
+
+      it 'returns http not found' do
+        update_candidate
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'POST /create' do
     subject(:create_candidate) { post '/api/v1/candidates', params: params }
 

--- a/spec/use_cases/candidates/create_use_case_spec.rb
+++ b/spec/use_cases/candidates/create_use_case_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Candidates::CreateUseCase do
 
     context 'when the candidate is valid' do
       before do
-        allow(Candidates::CreateValidator).to receive(:valid?).and_return(true)
+        allow(Candidates::UpsertValidator).to receive(:valid?).and_return(true)
       end
 
       it 'creates a candidate' do
@@ -26,7 +26,7 @@ RSpec.describe Candidates::CreateUseCase do
 
     context 'when the candidate is invalid' do
       before do
-        allow(Candidates::CreateValidator).to receive(:valid?).and_return(false)
+        allow(Candidates::UpsertValidator).to receive(:valid?).and_return(false)
       end
 
       it 'does not create a candidate' do

--- a/spec/use_cases/candidates/update_use_case_spec.rb
+++ b/spec/use_cases/candidates/update_use_case_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Candidates::UpdateUseCase do
+  describe '.call' do
+    subject(:update_use_case) { described_class.new(candidate_id, params).call }
+
+    let(:candidate_id) { candidate.id }
+    let(:params) do
+      {
+        name:      'John Doe',
+        email:     'john@doe.com',
+        birthdate: 20.years.ago
+      }
+    end
+
+    let(:candidate) { create(:candidate) }
+
+    context 'when the candidate is valid' do
+      it 'updates the candidate attributes' do
+        update_use_case
+        expect(candidate.reload).to have_attributes(
+          id:        candidate.id,
+          name:      'John Doe',
+          email:     'john@doe.com',
+          birthdate: 20.years.ago.to_date
+        )
+      end
+    end
+
+    context 'when the candidate is invalid' do
+      before { allow(Candidates::UpsertValidator).to receive(:valid?).and_return(false) }
+
+      it 'does not update the candidate attributes' do
+        update_use_case
+        expect(candidate.reload).to have_attributes(
+          id:        candidate.id,
+          name:      candidate.name,
+          email:     candidate.email,
+          birthdate: candidate.birthdate
+        )
+      end
+    end
+  end
+end

--- a/spec/validators/candidates/upsert_validator_spec.rb
+++ b/spec/validators/candidates/upsert_validator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Candidates::CreateValidator do
+RSpec.describe Candidates::UpsertValidator do
   describe '.valid?' do
     subject { described_class.valid?(candidate) }
 
@@ -24,6 +24,12 @@ RSpec.describe Candidates::CreateValidator do
 
     context 'when the email is invalid' do
       before { candidate.email = 'my.email.at.example.com' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the email is already taken' do
+      before { create(:candidate, email: candidate.email) }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
This pull request refactors the candidates controller by renaming the CreateValidator to UpsertValidator and adds an update action to the controller.

It also includes the necessary changes to the ApiController to handle error handling for ActiveRecord::RecordNotFound.