### PR TITLE
Add destroy action to CandidatesController

### DIFF
--- a/app/controllers/api/v1/candidates_controller.rb
+++ b/app/controllers/api/v1/candidates_controller.rb
@@ -35,6 +35,13 @@ module Api
         head :ok
       end
 
+      def destroy
+        candidate = Candidate.find(params[:id])
+        candidate.destroy
+
+        head :ok
+      end
+
       private
 
       def candidate_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :candidates, only: %i[create index show update]
+      resources :candidates, only: %i[create index show update destroy]
     end
   end
 

--- a/spec/requests/api/v1/candidates_request_spec.rb
+++ b/spec/requests/api/v1/candidates_request_spec.rb
@@ -168,4 +168,23 @@ RSpec.describe 'Api::V1::Candidates' do
       end
     end
   end
+
+  describe 'DELETE /:id' do
+    subject(:delete_candidate) { delete "/api/v1/candidates/#{candidate_id}" }
+
+    let(:candidate_id) { candidate.id }
+    let(:candidate) { create(:candidate) }
+
+    context 'with existing candidate' do
+      it 'returns http ok' do
+        delete_candidate
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'deletes the candidate' do
+        delete_candidate
+        expect(Candidate.find_by(id: candidate)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/candidates_request_swagger_spec.rb
+++ b/spec/requests/api/v1/candidates_request_swagger_spec.rb
@@ -91,5 +91,55 @@ describe 'Candidates API' do
         run_test!
       end
     end
+
+    put 'Updates a candidate' do
+      tags 'Candidates'
+      consumes 'application/json'
+      parameter name: :id, in: :path, type: :integer
+      parameter name: :candidate, in: :body, schema: {
+        type:       :object,
+        properties: {
+          name:      { type: :string, example: 'Andre' },
+          email:     { type: :string, format: :email, example: 'andre@haistack.ai' },
+          birthdate: { type: :string, format: :date, example: '1992-04-27' }
+        }
+      }
+
+      response '200', 'Candidate updated' do
+        let(:id) { create(:candidate).id }
+        let(:candidate) { { name: 'foo', email: 'andre@haistack.ai', birthdate: '1990-01-01' } }
+
+        run_test!
+      end
+
+      response '422', 'Invalid request' do
+        let(:id) { create(:candidate).id }
+        let(:candidate) { { email: 'foo' } }
+
+        run_test!
+      end
+
+      response '404', 'Candidate not found' do
+        let(:id) { 'invalid' }
+        let(:candidate) { { name: 'foo', email: 'andre@haistack.ai, birthdate: 1990-01-01' } }
+
+        run_test!
+      end
+    end
+
+    delete 'Deletes a candidate' do
+      tags 'Candidates'
+      parameter name: :id, in: :path, type: :integer
+
+      response '200', 'Candidate deleted' do
+        let(:id) { create(:candidate).id }
+        run_test!
+      end
+
+      response '404', 'Candidate not found' do
+        let(:id) { 'invalid' }
+        run_test!
+      end
+    end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -112,6 +112,55 @@ paths:
                     format: date
         '404':
           description: Candidate not found
+    put:
+      summary: Updates a candidate
+      tags:
+      - Candidates
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Candidate updated
+        '422':
+          description: Invalid request
+        '404':
+          description: Candidate not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Andre
+                email:
+                  type: string
+                  format: email
+                  example: andre@haistack.ai
+                birthdate:
+                  type: string
+                  format: date
+                  example: '1992-04-27'
+    delete:
+      summary: Deletes a candidate
+      tags:
+      - Candidates
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Candidate deleted
+        '404':
+          description: Candidate not found
 servers:
 - url: http://localhost:3000
   description: The local server


### PR DESCRIPTION
This pull request adds a destroy action to the CandidatesController, allowing candidates to be deleted from the database.

Also adds OpenAPI docs to Delete and Update actions